### PR TITLE
Support Repository Filtering in PR Generation

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="omega_moderne_client.filter.github._GitHubRobotFileParser.entries" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/omega-moderne-client.iml
+++ b/.idea/omega-moderne-client.iml
@@ -11,6 +11,9 @@
       <excludeFolder url="file://$MODULE_DIR$/venv" />
       <excludeFolder url="file://$MODULE_DIR$/.tox" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/omega_moderne_client.egg-info" />
+      <excludeFolder url="file://$MODULE_DIR$/.pytest_cache" />
+      <excludeFolder url="file://$MODULE_DIR$/.pytype" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.9 (omega-moderne-client)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/omega_moderne_client/campaign/campaign.py
+++ b/omega_moderne_client/campaign/campaign.py
@@ -67,11 +67,7 @@ class Campaign:
 
     @classmethod
     def _load_campaign_resource(cls, campaign: str, path: str) -> Traversable:
-        # pylint: disable-next=too-many-function-args
-        resource = cls._campaigns_dir().joinpath(
-            campaign,
-            path
-        )
+        resource = cls._campaigns_dir().joinpath(campaign).joinpath(path)
         if not resource.is_file():
             raise ValueError(f"File {path} does not exist, and must to create a campaign")
         return resource
@@ -80,12 +76,12 @@ class Campaign:
     def _load_file_contents(cls, campaign: str, path: str) -> str:
         resource = cls._load_campaign_resource(campaign, path)
         # noinspection PyTypeChecker
-        with open(resource, 'r', encoding='utf-8') as file:
+        with open(resource, 'r', encoding='utf-8') as file:  # pytype: disable=wrong-arg-types
             return file.read()
 
     @classmethod
     def _load_file_contents_as_title_and_body(cls, campaign: str, path: str) -> Tuple[str, str]:
         resource = cls._load_campaign_resource(campaign, path)
         # noinspection PyTypeChecker
-        with open(resource, 'r', encoding='utf-8') as file:
+        with open(resource, 'r', encoding='utf-8') as file:  # pytype: disable=wrong-arg-types
             return file.readline(), file.read()

--- a/omega_moderne_client/campaign/campaign_executor.py
+++ b/omega_moderne_client/campaign/campaign_executor.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from typing import Any, List, Dict
 
 from omega_moderne_client.client.gpg_key_config import GpgKeyConfig
-from omega_moderne_client.client.moderne_client import ModerneClient, RecipeRunSummary
+from omega_moderne_client.client.moderne_client import ModerneClient
+from ..client.client_types import RecipeRunSummary, Repository
 from .campaign import Campaign
 
 
@@ -68,7 +69,7 @@ class CampaignExecutor:
 @dataclass(frozen=True)
 class RecipeExecutionResult:
     run_id: str
-    repositories: List[Any]
+    repositories: List[Repository]
 
 
 class CampaignExecutorProgressMonitor(abc.ABC):

--- a/omega_moderne_client/client/client_types.py
+++ b/omega_moderne_client/client/client_types.py
@@ -1,0 +1,36 @@
+from typing import NamedTuple
+
+
+class RecipeRunSummary(NamedTuple):
+    debugMarkers: int
+    errorMarkers: int
+    infoMarkers: int
+    warningMarkers: int
+    timeSavings: str
+    totalChanged: int
+    totalSearched: int
+    state: str
+    performance: 'RecipeRunPerformance'
+    repository: 'Repository'
+
+
+class RecipeRunPerformance(NamedTuple):
+    recipeRun: str
+
+
+class Repository(NamedTuple):
+    origin: str
+    path: str
+    branch: str
+
+    def as_url(self):
+        return f"https://{self.origin}/{self.path}"
+
+
+class Commit(NamedTuple):
+    modified: str
+    repository: Repository
+    resultLink: str
+    state: str
+    """One of: "CANCELED", "COMPLETED", "FAILED", "NO_CHANGES", "ORPHANED, "PROCESSING", or "QUEUED"."""
+    stateMessage: str

--- a/omega_moderne_client/repository_filter/__init__.py
+++ b/omega_moderne_client/repository_filter/__init__.py
@@ -1,0 +1,86 @@
+"""Filtering the set of repositories to generate pull requests for."""
+import abc
+from dataclasses import dataclass
+from typing import List, Dict, Set
+
+from omega_moderne_client.campaign.campaign_executor import RecipeExecutionResult
+from omega_moderne_client.client.client_types import Repository
+from omega_moderne_client.repository_filter.filter_types import FilterDetailedReason, FilteredRecipeExecutionResult, \
+    FilterReason
+
+__all__ = ['Filter']
+
+
+class Filter(abc.ABC):
+    """A filter that can be applied to a repository to determine if it should be filtered out."""
+
+    @abc.abstractmethod
+    def should_filter_repository(self, repository: 'Repository') -> List[FilterDetailedReason]:
+        """Determine if the repository should be filtered out.
+
+        :param repository: The repository to check.
+        :return: The reason for why the repository was filtered out, or an empty list if it should not be filtered out.
+        """
+        raise NotImplementedError
+
+    def filter_repositories(self, recipe_execution_result: RecipeExecutionResult) -> FilteredRecipeExecutionResult:
+        """Filter the repositories in the given recipe execution result.
+
+        :param recipe_execution_result: The recipe execution result to filter.
+        :return: The filtered recipe execution result.
+        """
+        filtered_repositories: Dict[Repository, List[FilterDetailedReason]] = {}
+        for repository in recipe_execution_result.repositories:
+            filter_reasons = self.should_filter_repository(repository)
+            if filter_reasons:
+                filtered_repositories[repository] = filter_reasons
+        return FilteredRecipeExecutionResult(
+            run_id=recipe_execution_result.run_id,
+            repositories=list(set(recipe_execution_result.repositories) - set(filtered_repositories.keys())),
+            filtered_repositories=filtered_repositories
+        )
+
+    @classmethod
+    def create_all(cls) -> 'Filter':
+        """Create a filter that filters out repositories based on all reasons."""
+        return cls.create_filter(set(FilterReason))
+
+    @classmethod
+    def create_filter(cls, filter_reasons: Set[FilterReason]) -> 'Filter':
+        """Create a filter that filters out repositories based on the given reasons.
+
+        :param filter_reasons: The reasons to filter out repositories.
+        :return: The filter to use.
+        """
+
+        filters = [cls._filter_for_filter_reason(filter_reason) for filter_reason in filter_reasons]
+        return CombinedFilter(filters=filters)
+
+    @staticmethod
+    def _filter_for_filter_reason(filter_reason: FilterReason) -> 'Filter':
+        # pylint: disable=import-outside-toplevel
+        from omega_moderne_client.repository_filter.github import GitHubRobotsTxtFilter  # pylint: disable=cyclic-import
+        from omega_moderne_client.repository_filter.top_ten_thousand import \
+            TopTenThousandProjects  # pylint: disable=cyclic-import
+        from omega_moderne_client.repository_filter.other import OtherRepositoryFilter  # pylint: disable=cyclic-import
+
+        if filter_reason is FilterReason.GH_ROBOTS_TXT:
+            return GitHubRobotsTxtFilter()
+        if filter_reason is FilterReason.TOP_TEN_THOUSAND:
+            return TopTenThousandProjects.load_from_remote()
+        if filter_reason is FilterReason.OTHER:
+            return OtherRepositoryFilter()
+        raise ValueError(f"Unknown filter reason: {filter_reason}")
+
+
+@dataclass(frozen=True)
+class CombinedFilter(Filter):
+    """A filter that combines multiple filters together."""
+    filters: List[Filter]
+
+    def should_filter_repository(self, repository: 'Repository') -> List[FilterDetailedReason]:
+        """Determine if the repository should be filtered out."""
+        filter_reasons: List[FilterDetailedReason] = []
+        for the_filter in self.filters:
+            filter_reasons.extend(the_filter.should_filter_repository(repository))
+        return filter_reasons

--- a/omega_moderne_client/repository_filter/filter_types.py
+++ b/omega_moderne_client/repository_filter/filter_types.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List
+
+from omega_moderne_client.campaign.campaign_executor import RecipeExecutionResult
+from omega_moderne_client.client.client_types import Repository
+
+
+@dataclass(frozen=True)
+class FilterDetailedReason:
+    """A reason for why a repository was filtered out."""
+    reason: 'FilterReason'
+    """The details about why the repository was filtered out."""
+    details: str
+
+
+class FilterReason(Enum):
+    """The high level reason for why a repository was filtered out."""
+    GH_ROBOTS_TXT = "GH_ROBOTS_TXT"
+    """The repository has a .github/GH-ROBOTS.txt file that disallows the bot."""
+    TOP_TEN_THOUSAND = "TOP_TEN_THOUSAND"
+    """The repository is in the top 10,000 critical OSS projects."""
+    OTHER = "OTHER"
+    """The repository was filtered out for some other reason."""
+    # TODO: Use `StringEnum` when it's available in Python 3.11
+
+
+@dataclass(frozen=True)
+class FilteredRecipeExecutionResult(RecipeExecutionResult):
+    """The result of a recipe execution that has been filtered."""
+    filtered_repositories: Dict[Repository, List[FilterDetailedReason]]

--- a/omega_moderne_client/repository_filter/github.py
+++ b/omega_moderne_client/repository_filter/github.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass, field
+from typing import Optional, List
+from urllib.parse import urlparse, urlencode, urlunparse
+from urllib.robotparser import RobotFileParser
+
+import requests
+
+from omega_moderne_client.client.client_types import Repository
+from omega_moderne_client.repository_filter import Filter
+from omega_moderne_client.repository_filter.filter_types import FilterDetailedReason, FilterReason
+
+
+@dataclass(frozen=True)
+class GitHubRobotsTxtFilter(Filter):
+    """A filter that filters out repositories that have a .github/GH-ROBOTS.txt file that disallows the bot."""
+
+    user_agents: List[str] = field(
+        default_factory=lambda: ['JLLeitschuh/security-research']
+    )
+
+    def should_filter_repository(self, repository: 'Repository') -> List[FilterDetailedReason]:
+        """Determine if the repository should be filtered out."""
+        if repository.origin != 'github.com':
+            return []
+        user, repo = repository.path.split('/')
+        return self.should_filter(user, repo, repository.branch)
+
+    def should_filter(self, user: str, repository: str, branch: str) -> List[FilterDetailedReason]:
+        """Determine if the repository should be filtered out.
+
+        :param user: The user that owns the repository.
+        :param repository: The repository to check.
+        :param branch: The branch to check.
+        :return: The reason for why the repository was filtered out, or an empty list if it should not be filtered out.
+        """
+        parser = self._get_gh_robots_txt(user, repository, branch)
+        if parser is None:
+            return []
+        filter_reasons: List[FilterDetailedReason] = []
+        for user_agent in self.user_agents:
+            if parser.applies_to(user_agent):
+                reason = f"Repository {user}/{repository} is disallowed by .github/GH-ROBOTS.txt containing agent " \
+                         f"{user_agent}."
+                filter_reasons.append(
+                    FilterDetailedReason(
+                        reason=FilterReason.GH_ROBOTS_TXT,
+                        details=reason
+                    )
+                )
+        return filter_reasons
+
+    @classmethod
+    def _get_gh_robots_txt(cls, user: str, repository: str, branch: str) -> Optional['_GitHubRobotFileParser']:
+        """Get the contents of the .github/GH-ROBOTS.txt file if it's present."""
+        url = cls._build_url(
+            "https://raw.githubusercontent.com",
+            f"/{user}/{repository}/{branch}/.github/GH-ROBOTS.txt"
+        )
+        response = requests.get(url, timeout=10)
+        if response.status_code == 404:
+            return None
+        if response.status_code != 200:
+            response.raise_for_status()
+        return _GitHubRobotFileParser(response.text)
+
+    @staticmethod
+    def _build_url(base_url, path, args_dict=None) -> str:
+        # Returns a list in the structure of urlparse.ParseResult
+        if args_dict is None:
+            args_dict = {}
+        url_parts = list(urlparse(base_url))
+        url_parts[2] = path
+        url_parts[4] = urlencode(args_dict)
+        return urlunparse(url_parts)
+
+
+class _GitHubRobotFileParser(RobotFileParser):
+    """A RobotFileParser that can be used to parse the contents of a .github/GH-ROBOTS.txt file."""
+
+    def __init__(self, content: str):
+        super().__init__()
+        self.parse(content.splitlines())
+
+    def applies_to(self, useragent: str) -> bool:
+        """Determine if the user agent is allowed to access the repository.
+
+        :param useragent: The user agent to check.
+        :return: True if the user agent is allowed to access the repository.
+        """
+        for entry in self.entries:  # pytype: disable=attribute-error
+            if self._applies_to_entry(useragent, entry):
+                return True
+        return False
+
+    @staticmethod
+    def _applies_to_entry(useragent: str, entry) -> bool:
+        """Determine if the user agent is allowed to access the repository.
+
+        :param useragent: The user agent to check.
+        :return: True if the user agent is allowed to access the repository.
+        """
+        # check if this entry applies to the specified agent
+        # split the name token and make it lower case
+        useragent = useragent.lower()
+        for agent in entry.useragents:
+            if agent == '*':
+                # we have the catch-all agent
+                return True
+            agent = agent.lower()
+            if agent in useragent:
+                return True
+        return False

--- a/omega_moderne_client/repository_filter/other.py
+++ b/omega_moderne_client/repository_filter/other.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+from omega_moderne_client.client.client_types import Repository
+from omega_moderne_client.repository_filter import Filter, FilterDetailedReason, FilterReason
+
+
+@dataclass(frozen=True)
+class OtherRepositoryFilter(Filter):
+    """A filter that filters out repositories based on the other reason."""
+    repository_to_reasons: Dict[str, List[str]] = field(default_factory=lambda: {
+        "https://github.com/wmaintw/DependencyCheck": [
+            "Fork of the upstream `jeremylong/DependencyCheck`"
+        ]
+    })
+
+    def should_filter_repository(self, repository: 'Repository') -> List[FilterDetailedReason]:
+        """Determine if the repository should be filtered out.
+
+        :param repository: The repository to check.
+        :return: The reason for why the repository was filtered out, or an empty list if it should not be filtered out.
+        """
+        if repository.as_url() in self.repository_to_reasons:
+            return [FilterDetailedReason(reason=FilterReason.OTHER, details=reason) for reason in
+                    self.repository_to_reasons[repository.as_url()]]
+        return []

--- a/omega_moderne_client/repository_filter/top_ten_thousand.py
+++ b/omega_moderne_client/repository_filter/top_ten_thousand.py
@@ -1,0 +1,34 @@
+import csv
+from dataclasses import dataclass
+from typing import List, Dict
+
+import requests
+
+from omega_moderne_client.client.client_types import Repository
+from omega_moderne_client.repository_filter import Filter
+from omega_moderne_client.repository_filter.filter_types import FilterDetailedReason, FilterReason
+
+
+@dataclass(frozen=True)
+class TopTenThousandProjects(Filter):
+    list: List[Dict[str, str]]
+
+    def should_filter_repository(self, repository: 'Repository') -> List[FilterDetailedReason]:
+        repository_url = f"https://{repository.origin}/{repository.path}"
+        for project in self.list:
+            if project['URL'] == repository_url:
+                return [FilterDetailedReason(
+                    FilterReason.TOP_TEN_THOUSAND,
+                    'The repository is in the top 10,000 critical OSS projects.'
+                )]
+        return []
+
+    @staticmethod
+    def load_from_remote() -> 'TopTenThousandProjects':
+        # pylint: disable=line-too-long
+        csv_url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQJjUIa78qOs19mmZ2AmpehplONAsnAsAoji-oQcd8phurjEyoG6_BgPeTgCYzAtEzgkC_W6Bx2LZOD/pub?output=csv'  # noqa
+        response = requests.get(csv_url, timeout=10)
+        response.raise_for_status()
+        # Pre-filter for elements that have a URL
+        top_ten_thousand_csv = [element for element in csv.DictReader(response.text.splitlines()) if element['URL']]
+        return TopTenThousandProjects(top_ten_thousand_csv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools>=67.6.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytype]
+inputs = ['omega-moderne-client.py', 'omega_moderne_client', 'tests']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ setuptools>=67.6.0
 rich~=13.3.2
 gql[all]>=3.4.0
 isodate>=0.6.1
+
+pytz~=2022.7.1
+croniter~=1.3.8
+dataclasses~=0.6
+requests>=2.28.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ if __name__ == "__main__":
         ],
         python_requires='>=3.6',
         install_requires=[
-          "gql[all]>=3.4.0"
+            "gql[all]>=3.4.0",
+            "requests>=2.28.2"
         ],
         extras_require={
             "cli": [

--- a/tests/repository_filter/filter_test.py
+++ b/tests/repository_filter/filter_test.py
@@ -1,0 +1,23 @@
+from omega_moderne_client.campaign.campaign_executor import RecipeExecutionResult
+from omega_moderne_client.client.client_types import Repository
+from omega_moderne_client.repository_filter import Filter
+
+OMEGA_MODERNE_CLIENT_REPOSITORY = Repository(
+    origin="github.com",
+    path="ossf/omega-moderne-client",
+    branch="main",
+)
+
+
+def test_loaded_filters():
+    repository_filter = Filter.create_all()
+    assert repository_filter is not None
+    filtered_repositories = repository_filter.filter_repositories(
+        RecipeExecutionResult(
+            run_id="run_id",
+            repositories=[OMEGA_MODERNE_CLIENT_REPOSITORY]
+        )
+    )
+    assert filtered_repositories is not None
+    assert filtered_repositories.repositories == [OMEGA_MODERNE_CLIENT_REPOSITORY]
+    assert not filtered_repositories.filtered_repositories

--- a/tests/repository_filter/github_test.py
+++ b/tests/repository_filter/github_test.py
@@ -1,0 +1,25 @@
+# pylint: disable=protected-access
+from omega_moderne_client.repository_filter.filter_types import FilterReason
+from omega_moderne_client.repository_filter.github import GitHubRobotsTxtFilter
+
+
+def test_repository_with_gh_robots_txt():
+    parser = GitHubRobotsTxtFilter._get_gh_robots_txt("JLLeitschuh", "code-sandbox", "main")
+    assert parser is not None
+    assert parser.applies_to("JLLeitschuh/security-research")
+    assert not parser.applies_to('ossf/omega-moderne-client')
+
+
+def test_repository_without_gh_robots_txt():
+    parser = GitHubRobotsTxtFilter._get_gh_robots_txt("ossf", "omega-moderne-client", "main")
+    assert parser is None
+
+
+def test_repository_filter():
+    gh_robots_filter = GitHubRobotsTxtFilter()
+    reasons = gh_robots_filter.should_filter("JLLeitschuh", "code-sandbox", "main")
+    assert len(reasons) == 1
+    assert reasons[0].reason == FilterReason.GH_ROBOTS_TXT
+    assert reasons[0].details ==\
+           "Repository JLLeitschuh/code-sandbox is disallowed by .github/GH-ROBOTS.txt containing agent " \
+           "JLLeitschuh/security-research."

--- a/tests/repository_filter/top_ten_thousand_test.py
+++ b/tests/repository_filter/top_ten_thousand_test.py
@@ -1,0 +1,18 @@
+from omega_moderne_client.client.client_types import Repository
+from omega_moderne_client.repository_filter.filter_types import FilterReason
+from omega_moderne_client.repository_filter.top_ten_thousand import TopTenThousandProjects
+
+
+def test_load_top_ten_thousand():
+    top_ten_thousand = TopTenThousandProjects.load_from_remote()
+    assert len(top_ten_thousand.list) >= 5_000
+    omega_filter_details = top_ten_thousand.should_filter_repository(
+        Repository(**{'origin': 'github.com', 'path': 'ossf/omega-moderne-client', 'branch': 'main'})
+    )
+    assert len(omega_filter_details) == 0
+    filter_details = top_ten_thousand.should_filter_repository(
+        Repository(**{'origin': 'github.com', 'path': 'apache/struts', 'branch': 'main'})
+    )
+    assert len(filter_details) == 1
+    assert filter_details[0].reason == FilterReason.TOP_TEN_THOUSAND
+    assert filter_details[0].details == 'The repository is in the top 10,000 critical OSS projects.'

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,11 @@ description = Lint the code with pylint
 deps = pylint
 commands = pylint --rcfile=.pylintrc  omega-moderne-client omega_moderne_client tests
 
+[testenv:pytype]
+description = Type check the code with pytype
+deps = pytype>=2023.3
+commands = pytype
+
 [testenv:check-manifest]
 skip_install = true
 deps = check-manifest


### PR DESCRIPTION
Allows the list of repositories to be filtered by the top 10k repository list, and by repositories that have opted out with the `GH-ROBOTS.txt`.

Also, the types returned from the `ModerneClient` have been converted from `TypeDict` to `NamedTuple` to make them immutable and have consistent hash values.

Also adds testing the code with google/pytype